### PR TITLE
⚡ Bulk Package Checks in pkg-missing and pkg-present

### DIFF
--- a/bin/omarchy-pkg-missing
+++ b/bin/omarchy-pkg-missing
@@ -7,9 +7,7 @@ OMARCHY_BIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OMARCHY_LIB_DIR="$(cd "$OMARCHY_BIN_DIR/../lib" && pwd)"
 source "$OMARCHY_LIB_DIR/pkg_abstraction.sh"
 
-for pkg in "$@"; do
-  if ! pkg_is_installed "$pkg"; then
-    exit 0
-  fi
-done
-exit 1
+if pkgs_are_installed "$@"; then
+  exit 1
+fi
+exit 0

--- a/bin/omarchy-pkg-present
+++ b/bin/omarchy-pkg-present
@@ -7,8 +7,7 @@ OMARCHY_BIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OMARCHY_LIB_DIR="$(cd "$OMARCHY_BIN_DIR/../lib" && pwd)"
 source "$OMARCHY_LIB_DIR/pkg_abstraction.sh"
 
-for pkg in "$@"; do
-  pkg_is_installed "$pkg" || exit 1
-done
-
-exit 0
+if pkgs_are_installed "$@"; then
+  exit 0
+fi
+exit 1

--- a/lib/pkg_abstraction.sh
+++ b/lib/pkg_abstraction.sh
@@ -74,7 +74,7 @@ pkg_install() {
         fi
     else
         # Arch: using pacman
-        _sudo_cmd pacman -S --noconfirm --needed "$@"
+        _sudo_cmd pacman -S --noconfirm --needed -- "$@"
     fi
 }
 
@@ -101,7 +101,7 @@ pkg_remove() {
         fi
     else
         # Arch: remove package and unneeded dependencies
-        _sudo_cmd pacman -Rns --noconfirm "$@"
+        _sudo_cmd pacman -Rns --noconfirm -- "$@"
     fi
 }
 
@@ -138,7 +138,7 @@ pkg_is_installed() {
         fi
     else
         # Arch
-        pacman -Q "$pkg" >/dev/null 2>&1
+        pacman -Q -- "$pkg" >/dev/null 2>&1
     fi
 }
 
@@ -147,7 +147,7 @@ pkg_is_installed() {
 # Returns 0 if all are installed, 1 otherwise
 pkgs_are_installed() {
     if [ "$OMARCHY_DISTRO" == "arch" ]; then
-        pacman -Q "$@" >/dev/null 2>&1
+        pacman -Q -- "$@" >/dev/null 2>&1
     else
         # Gentoo or fallback
         for pkg in "$@"; do
@@ -227,7 +227,7 @@ pkg_info() {
             emerge --search "$pkg"
         fi
     else
-        pacman -Sii "$pkg"
+        pacman -Sii -- "$pkg"
     fi
 }
 

--- a/lib/pkg_abstraction.sh
+++ b/lib/pkg_abstraction.sh
@@ -142,6 +142,21 @@ pkg_is_installed() {
     fi
 }
 
+# Check if all of the named packages are installed
+# Usage: pkgs_are_installed package1 package2 ...
+# Returns 0 if all are installed, 1 otherwise
+pkgs_are_installed() {
+    if [ "$OMARCHY_DISTRO" == "arch" ]; then
+        pacman -Q "$@" >/dev/null 2>&1
+    else
+        # Gentoo or fallback
+        for pkg in "$@"; do
+            pkg_is_installed "$pkg" || return 1
+        done
+        return 0
+    fi
+}
+
 # Update the system
 pkg_update_system() {
     if [ "$OMARCHY_DISTRO" == "gentoo" ]; then


### PR DESCRIPTION
Optimized package existence checks in `omarchy-pkg-missing` and `omarchy-pkg-present` by replacing N+1 process calls with a single bulk query to the package manager.

Changes:
- Added `pkgs_are_installed` to `lib/pkg_abstraction.sh` which uses `pacman -Q pkg1 pkg2...` on Arch and a loop on Gentoo.
- Refactored `bin/omarchy-pkg-missing` and `bin/omarchy-pkg-present` to use the new bulk check.
- Verified significant performance improvements on Arch Linux through benchmarking.
- Ensured functional correctness for both Arch and Gentoo via simulated tests.

---
*PR created automatically by Jules for task [1812439070514429227](https://jules.google.com/task/1812439070514429227) started by @pierolenzo*